### PR TITLE
feat(ci): 新增 Google Drive PR 描述自動保存功能

### DIFF
--- a/.github/workflows/save-pr-to-gdrive.yml
+++ b/.github/workflows/save-pr-to-gdrive.yml
@@ -1,0 +1,68 @@
+name: Save PR Description to Google Drive
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+jobs:
+  upload-pr-desc:
+    runs-on: ubuntu-latest
+    steps:
+      # 1. Checkout 並保留推送權限
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: true
+
+      # 2. 讀取 PR body，寫成 markdown 檔案
+      - name: Generate PR description file
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = context.payload.pull_request;
+            const branch = pr.head.ref;                  // PR 分支名稱
+            const filename = `${branch}.md`;             // 例如 feature/foo.md
+            const header = `# PR #${pr.number} - ${pr.title}\n\n`;
+            const body   = pr.body || "_(no description)_";
+            const fs = require('fs');
+            fs.writeFileSync(filename, header + body + "\n");
+            core.info(`Generated ${filename}`);
+
+      # 3. 安裝 rclone（用它上傳到 Drive）
+      - name: Install rclone
+        run: curl https://rclone.org/install.sh | bash
+
+      # 4. 配置 rclone remote（直接使用完整的配置）
+      - name: Configure rclone
+        run: |
+          mkdir -p ~/.config/rclone
+          echo "${{ secrets.RCLONE_TOKEN }}" > ~/.config/rclone/rclone.conf
+
+      # 5. 驗證配置並測試連接
+      - name: Test rclone connection
+        run: |
+          echo "測試 rclone 配置..."
+          rclone config show gdrive
+          echo "測試 Google Drive 連接..."
+          rclone ls gdrive: | head -5 || echo "無法列出根目錄，但可能仍可上傳到指定資料夾"
+
+      # 6. 上傳到 Google Drive 指定資料夾
+      - name: Upload to Google Drive
+        run: |
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          SAFE_BRANCH=$(echo "$BRANCH" | sed 's/[\/:]/-/g')
+          echo "上傳分支: $BRANCH"
+          echo "安全檔名: ${SAFE_BRANCH}.md"
+          
+          # 確保目標資料夾存在（如果不存在會自動建立）
+          rclone copy "${BRANCH}.md" "gdrive:GitHub-PR-Descriptions/" --create-dest-dirs
+          
+          echo "✅ 檔案已上傳到 Google Drive"
+
+      # 7. 清理工作目錄
+      - name: Cleanup
+        if: always()
+        run: |
+          rm -f "${{ github.event.pull_request.head.ref }}.md"
+          rm -f ~/.config/rclone/rclone.conf 

--- a/.github/workflows/save-pr-to-gdrive.yml
+++ b/.github/workflows/save-pr-to-gdrive.yml
@@ -1,4 +1,5 @@
-name: Save PR Description to Google Drive
+# .github/workflows/pr-to-gdrive-sa.yml
+name: Save PR Description with Service Account
 
 on:
   pull_request:
@@ -8,112 +9,26 @@ jobs:
   upload-pr-desc:
     runs-on: ubuntu-latest
     steps:
-      # 1. Checkout 並保留推送權限
-      - name: Checkout repo
+      - name: Checkout
         uses: actions/checkout@v4
-        with:
-          persist-credentials: true
 
-      # 2. 讀取 PR body，寫成 markdown 檔案
       - name: Generate PR description file
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const pr = context.payload.pull_request;
-            const branch = pr.head.ref;                  // PR 分支名稱
-            const safeBranch = branch.replace(/[\/:]/, '-'); // 替換特殊字元
-            const filename = `${safeBranch}.md`;         // 安全的檔案名稱
-            const header = `# PR #${pr.number} - ${pr.title}\n\n**分支**: ${branch}\n\n`;
-            const body   = pr.body || "_(no description)_";
-            const fs = require('fs');
-            fs.writeFileSync(filename, header + body + "\n");
-            core.info(`Generated ${filename} for branch ${branch}`);
+            const pr     = context.payload.pull_request;
+            const branch = pr.head.ref;
+            const file   = `${branch}.md`;
+            require('fs').writeFileSync(
+              file,
+              `# PR #${pr.number} – ${pr.title}\n\n${pr.body||"_no description_"}\n`
+            );
+            core.info(`Generated ${file}`);
 
-      # 3. 安裝 rclone（手動安裝避免權限問題）
-      - name: Install rclone
-        run: |
-          # 下載 rclone
-          curl -O https://downloads.rclone.org/rclone-current-linux-amd64.zip
-          unzip rclone-current-linux-amd64.zip
-          
-          # 複製到本地 bin 目錄
-          mkdir -p ~/bin
-          cp rclone-*/rclone ~/bin/
-          chmod +x ~/bin/rclone
-          
-          # 加入到 PATH
-          echo "$HOME/bin" >> $GITHUB_PATH
-          
-          # 驗證安裝
-          ~/bin/rclone version
-
-      # 4. 配置 rclone remote（直接使用完整的配置）
-      - name: Configure rclone
-        run: |
-          mkdir -p ~/.config/rclone
-          
-          # 檢查 RCLONE_TOKEN 是否存在
-          if [ -z "${{ secrets.RCLONE_TOKEN }}" ]; then
-            echo "❌ RCLONE_TOKEN Secret 未設定"
-            echo "請在 GitHub repository → Settings → Secrets and variables → Actions 中設定 RCLONE_TOKEN"
-            exit 1
-          fi
-          
-          # 寫入配置檔案
-          echo "${{ secrets.RCLONE_TOKEN }}" > ~/.config/rclone/rclone.conf
-          
-          # 檢查配置檔案是否正確寫入
-          echo "📋 檢查 rclone 配置檔案..."
-          if [ ! -f ~/.config/rclone/rclone.conf ]; then
-            echo "❌ 配置檔案建立失敗"
-            exit 1
-          fi
-          
-          echo "✅ 配置檔案已建立"
-          echo "檔案大小: $(wc -c < ~/.config/rclone/rclone.conf) bytes"
-
-      # 5. 驗證配置並測試連接
-      - name: Test rclone connection
-        run: |
-          echo "🔍 檢查所有可用的 rclone remotes..."
-          ~/bin/rclone listremotes
-          
-          echo ""
-          echo "📋 顯示 gdrive 配置..."
-          ~/bin/rclone config show gdrive || {
-            echo "❌ 找不到 gdrive 配置"
-            echo ""
-            echo "🔧 完整配置檔案內容:"
-            cat ~/.config/rclone/rclone.conf | sed 's/private_key.*"/private_key":"[REDACTED]"/g'
-            exit 1
-          }
-          
-          echo ""
-          echo "🧪 測試 Google Drive 連接..."
-          ~/bin/rclone ls gdrive: | head -5 || echo "⚠️ 無法列出根目錄，但可能仍可上傳到指定資料夾"
-
-      # 6. 上傳到 Google Drive 指定資料夾
-      - name: Upload to Google Drive
-        run: |
-          BRANCH="${{ github.event.pull_request.head.ref }}"
-          SAFE_BRANCH=$(echo "$BRANCH" | sed 's/[\/:]/-/g')
-          echo "上傳分支: $BRANCH"
-          echo "安全檔名: ${SAFE_BRANCH}.md"
-          
-          # 先確保目標資料夾存在
-          ~/bin/rclone mkdir "gdrive:GitHub-PR-Descriptions" || echo "資料夾可能已存在"
-          
-          # 上傳檔案到 Google Drive（使用安全檔名）
-          ~/bin/rclone copy "${SAFE_BRANCH}.md" "gdrive:GitHub-PR-Descriptions/"
-          
-          echo "✅ 檔案已上傳到 Google Drive"
-
-      # 7. 清理工作目錄
-      - name: Cleanup
-        if: always()
-        run: |
-          BRANCH="${{ github.event.pull_request.head.ref }}"
-          SAFE_BRANCH=$(echo "$BRANCH" | sed 's/[\/:]/-/g')
-          rm -f "${SAFE_BRANCH}.md"
-          rm -f ~/.config/rclone/rclone.conf 
+      - name: Upload to Google Drive via Service Account
+        uses: willo32/google-drive-upload-action@v1
+        with:
+          credentials: ${{ secrets.GDRIVE_SA_JSON }}   # 整份 Service Account JSON
+          target:      ${{ github.event.pull_request.head.ref }}.md
+          parent_folder_id: ${{ secrets.GDRIVE_FOLDER_ID }}  # 目的資料夾的 ID

--- a/.github/workflows/save-pr-to-gdrive.yml
+++ b/.github/workflows/save-pr-to-gdrive.yml
@@ -22,12 +22,13 @@ jobs:
           script: |
             const pr = context.payload.pull_request;
             const branch = pr.head.ref;                  // PR 分支名稱
-            const filename = `${branch}.md`;             // 例如 feature/foo.md
-            const header = `# PR #${pr.number} - ${pr.title}\n\n`;
+            const safeBranch = branch.replace(/[\/:]/, '-'); // 替換特殊字元
+            const filename = `${safeBranch}.md`;         // 安全的檔案名稱
+            const header = `# PR #${pr.number} - ${pr.title}\n\n**分支**: ${branch}\n\n`;
             const body   = pr.body || "_(no description)_";
             const fs = require('fs');
             fs.writeFileSync(filename, header + body + "\n");
-            core.info(`Generated ${filename}`);
+            core.info(`Generated ${filename} for branch ${branch}`);
 
       # 3. 安裝 rclone（手動安裝避免權限問題）
       - name: Install rclone
@@ -69,8 +70,11 @@ jobs:
           echo "上傳分支: $BRANCH"
           echo "安全檔名: ${SAFE_BRANCH}.md"
           
-          # 確保目標資料夾存在（如果不存在會自動建立）
-          ~/bin/rclone copy "${BRANCH}.md" "gdrive:GitHub-PR-Descriptions/" --create-dest-dirs
+          # 先確保目標資料夾存在
+          ~/bin/rclone mkdir "gdrive:GitHub-PR-Descriptions" || echo "資料夾可能已存在"
+          
+          # 上傳檔案到 Google Drive（使用安全檔名）
+          ~/bin/rclone copy "${SAFE_BRANCH}.md" "gdrive:GitHub-PR-Descriptions/"
           
           echo "✅ 檔案已上傳到 Google Drive"
 
@@ -78,5 +82,7 @@ jobs:
       - name: Cleanup
         if: always()
         run: |
-          rm -f "${{ github.event.pull_request.head.ref }}.md"
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          SAFE_BRANCH=$(echo "$BRANCH" | sed 's/[\/:]/-/g')
+          rm -f "${SAFE_BRANCH}.md"
           rm -f ~/.config/rclone/rclone.conf 

--- a/.github/workflows/save-pr-to-gdrive.yml
+++ b/.github/workflows/save-pr-to-gdrive.yml
@@ -29,9 +29,23 @@ jobs:
             fs.writeFileSync(filename, header + body + "\n");
             core.info(`Generated ${filename}`);
 
-      # 3. 安裝 rclone（用它上傳到 Drive）
+      # 3. 安裝 rclone（手動安裝避免權限問題）
       - name: Install rclone
-        run: curl https://rclone.org/install.sh | bash
+        run: |
+          # 下載 rclone
+          curl -O https://downloads.rclone.org/rclone-current-linux-amd64.zip
+          unzip rclone-current-linux-amd64.zip
+          
+          # 複製到本地 bin 目錄
+          mkdir -p ~/bin
+          cp rclone-*/rclone ~/bin/
+          chmod +x ~/bin/rclone
+          
+          # 加入到 PATH
+          echo "$HOME/bin" >> $GITHUB_PATH
+          
+          # 驗證安裝
+          ~/bin/rclone version
 
       # 4. 配置 rclone remote（直接使用完整的配置）
       - name: Configure rclone
@@ -43,9 +57,9 @@ jobs:
       - name: Test rclone connection
         run: |
           echo "測試 rclone 配置..."
-          rclone config show gdrive
+          ~/bin/rclone config show gdrive
           echo "測試 Google Drive 連接..."
-          rclone ls gdrive: | head -5 || echo "無法列出根目錄，但可能仍可上傳到指定資料夾"
+          ~/bin/rclone ls gdrive: | head -5 || echo "無法列出根目錄，但可能仍可上傳到指定資料夾"
 
       # 6. 上傳到 Google Drive 指定資料夾
       - name: Upload to Google Drive
@@ -56,7 +70,7 @@ jobs:
           echo "安全檔名: ${SAFE_BRANCH}.md"
           
           # 確保目標資料夾存在（如果不存在會自動建立）
-          rclone copy "${BRANCH}.md" "gdrive:GitHub-PR-Descriptions/" --create-dest-dirs
+          ~/bin/rclone copy "${BRANCH}.md" "gdrive:GitHub-PR-Descriptions/" --create-dest-dirs
           
           echo "✅ 檔案已上傳到 Google Drive"
 

--- a/.github/workflows/save-pr-to-gdrive.yml
+++ b/.github/workflows/save-pr-to-gdrive.yml
@@ -52,15 +52,46 @@ jobs:
       - name: Configure rclone
         run: |
           mkdir -p ~/.config/rclone
+          
+          # 檢查 RCLONE_TOKEN 是否存在
+          if [ -z "${{ secrets.RCLONE_TOKEN }}" ]; then
+            echo "❌ RCLONE_TOKEN Secret 未設定"
+            echo "請在 GitHub repository → Settings → Secrets and variables → Actions 中設定 RCLONE_TOKEN"
+            exit 1
+          fi
+          
+          # 寫入配置檔案
           echo "${{ secrets.RCLONE_TOKEN }}" > ~/.config/rclone/rclone.conf
+          
+          # 檢查配置檔案是否正確寫入
+          echo "📋 檢查 rclone 配置檔案..."
+          if [ ! -f ~/.config/rclone/rclone.conf ]; then
+            echo "❌ 配置檔案建立失敗"
+            exit 1
+          fi
+          
+          echo "✅ 配置檔案已建立"
+          echo "檔案大小: $(wc -c < ~/.config/rclone/rclone.conf) bytes"
 
       # 5. 驗證配置並測試連接
       - name: Test rclone connection
         run: |
-          echo "測試 rclone 配置..."
-          ~/bin/rclone config show gdrive
-          echo "測試 Google Drive 連接..."
-          ~/bin/rclone ls gdrive: | head -5 || echo "無法列出根目錄，但可能仍可上傳到指定資料夾"
+          echo "🔍 檢查所有可用的 rclone remotes..."
+          ~/bin/rclone listremotes
+          
+          echo ""
+          echo "📋 顯示 gdrive 配置..."
+          ~/bin/rclone config show gdrive || {
+            echo "❌ 找不到 gdrive 配置"
+            echo ""
+            echo "🔧 完整配置檔案內容:"
+            cat ~/.config/rclone/rclone.conf | sed 's/private_key.*"/private_key":"[REDACTED]"/g'
+            exit 1
+          }
+          
+          echo ""
+          echo "🧪 測試 Google Drive 連接..."
+          ~/bin/rclone ls gdrive: | head -5 || echo "⚠️ 無法列出根目錄，但可能仍可上傳到指定資料夾"
 
       # 6. 上傳到 Google Drive 指定資料夾
       - name: Upload to Google Drive

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,3 +29,49 @@ jobs:
       run: |
         docker compose -f docker-compose.test.yml down
         docker rm -f todo-mysql-test || true
+
+  # 新增：保存 PR 描述到 Google Drive（僅在 PR 事件時執行）
+  save-pr-description:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: true
+
+      - name: Generate PR description file
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = context.payload.pull_request;
+            const branch = pr.head.ref;
+            const filename = `${branch}.md`;
+            const header = `# PR #${pr.number} - ${pr.title}\n\n`;
+            const body = pr.body || "_(no description)_";
+            const fs = require('fs');
+            fs.writeFileSync(filename, header + body + "\n");
+            core.info(`Generated ${filename}`);
+
+      - name: Install rclone
+        run: curl https://rclone.org/install.sh | bash
+
+      - name: Configure rclone
+        run: |
+          mkdir -p ~/.config/rclone
+          cat <<EOF > ~/.config/rclone/rclone.conf
+          [gdrive]
+          type = drive
+          scope = drive.file
+          token = ${{ secrets.RCLONE_TOKEN }}
+          EOF
+
+      - name: Upload to Google Drive
+        run: |
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          SAFE_BRANCH=$(echo "$BRANCH" | sed 's/[\/:]/-/g')
+          rclone copy "${BRANCH}.md" "gdrive:GitHub-PR-Descriptions/${SAFE_BRANCH}.md"
+
+      - name: Cleanup
+        run: rm "${{ github.event.pull_request.head.ref }}.md"

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,36 @@
-node_modules
-.env
+# Dependency directories
+node_modules/
+npm-debug.log*
+
+# OS generated files
 .DS_Store
-npm-debug.log
-coverage/
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# IDE files
+.vscode/
+.idea/
+
+# Environment variables
+.env
+.env.local
+.env.*.local
+
+# Service Account credentials (NEVER commit these!)
+*.json
+*-service-account*.json
+*-credentials*.json
+service-account*.json
+
+# rclone config files
+rclone.conf
+rclone-config.txt
+
+# Test files
+test-*.md
+
+.env

--- a/README-GDRIVE-SETUP.md
+++ b/README-GDRIVE-SETUP.md
@@ -1,0 +1,61 @@
+# Google Drive PR 描述自動保存設定
+
+這個功能會自動將 Pull Request 的描述保存到 Google Drive，方便進行 PR 管理和文檔歸檔。
+
+## 🚀 快速設定（已有 Service Account）
+
+如果您已經有 Google Service Account JSON 檔案，可以使用我們的自動化工具：
+
+```bash
+# 使用 Python 腳本自動轉換
+python3 scripts/generate-rclone-token.py /path/to/your/service-account.json
+```
+
+腳本會輸出您需要設定到 GitHub Secrets 的 `RCLONE_TOKEN` 內容。
+
+## 📋 設定步驟總覽
+
+### 1. Google Cloud 設定
+- ✅ 建立 Google Cloud Project
+- ✅ 啟用 Google Drive API  
+- ✅ 建立 Service Account
+- ✅ 下載 JSON 金鑰檔案
+
+### 2. Google Drive 設定
+- ✅ 建立 `GitHub-PR-Descriptions` 資料夾
+- ✅ 分享資料夾給 Service Account email
+- ✅ 給予編輯者權限
+
+### 3. GitHub 設定
+- ✅ 設定 `RCLONE_TOKEN` Secret
+- ✅ 啟用 `.github/workflows/save-pr-to-gdrive.yml`
+
+## 🔧 工具說明
+
+- **完整設定指南**: `docs/setup-google-drive-integration.md`
+- **Service Account 快速設定**: `docs/service-account-direct-setup.md`
+- **自動轉換工具**: `scripts/generate-rclone-token.py`
+- **手動設定腳本**: `scripts/setup-gdrive-token.sh`
+
+## 🧪 測試
+
+設定完成後，建立任何 PR 都會自動：
+1. 讀取 PR 標題和描述
+2. 產生對應的 Markdown 檔案
+3. 上傳到 Google Drive 的 `GitHub-PR-Descriptions` 資料夾
+
+檔案命名格式：`{branch-name}.md`
+
+## 🔒 安全注意事項
+
+- Service Account JSON 檔案包含敏感資訊，請勿提交到 git
+- 定期輪換 Service Account 金鑰
+- 只給予必要的最小權限（drive.file scope）
+
+## 🛠️ 故障排除
+
+如果上傳失敗，請檢查：
+1. Service Account email 是否有資料夾編輯權限
+2. Google Drive API 是否已啟用
+3. RCLONE_TOKEN 格式是否正確
+4. 資料夾名稱是否為 `GitHub-PR-Descriptions` 

--- a/docs/service-account-direct-setup.md
+++ b/docs/service-account-direct-setup.md
@@ -1,0 +1,67 @@
+# Service Account 直接設定指南
+
+如果您已經有 Google Service Account 的 JSON 金鑰檔案，可以直接設定而不需要本機安裝 rclone。
+
+## 前提條件
+
+✅ 已有 Google Cloud Project  
+✅ 已啟用 Google Drive API  
+✅ 已建立 Service Account 並下載 JSON 金鑰檔案  
+✅ 已在 Google Drive 建立 `GitHub-PR-Descriptions` 資料夾  
+✅ 已將資料夾分享給 Service Account 的 email（在 JSON 檔案的 `client_email` 欄位）  
+
+## 快速設定方法
+
+### 步驟 1: 準備 rclone 配置內容
+
+將以下模板複製，並替換 `YOUR_SERVICE_ACCOUNT_JSON_CONTENT`：
+
+```ini
+[gdrive]
+type = drive
+scope = drive.file
+service_account_credentials = YOUR_SERVICE_ACCOUNT_JSON_CONTENT
+```
+
+### 步驟 2: 替換 Service Account 內容
+
+將您的 Service Account JSON 檔案內容壓縮成一行，替換上面的 `YOUR_SERVICE_ACCOUNT_JSON_CONTENT`。
+
+例如，如果您的 JSON 檔案內容是：
+```json
+{
+  "type": "service_account",
+  "project_id": "your-project",
+  "private_key_id": "abc123",
+  "private_key": "-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n",
+  "client_email": "github-actions@your-project.iam.gserviceaccount.com",
+  "client_id": "123456789",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token"
+}
+```
+
+將其壓縮成一行（移除換行和多餘空格）：
+```
+{"type":"service_account","project_id":"your-project","private_key_id":"abc123","private_key":"-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n","client_email":"github-actions@your-project.iam.gserviceaccount.com","client_id":"123456789","auth_uri":"https://accounts.google.com/o/oauth2/auth","token_uri":"https://oauth2.googleapis.com/token"}
+```
+
+### 步驟 3: 最終的 rclone 配置
+
+```ini
+[gdrive]
+type = drive
+scope = drive.file
+service_account_credentials = {"type":"service_account","project_id":"your-project",...}
+```
+
+### 步驟 4: 設定 GitHub Secret
+
+1. 前往 GitHub repository → Settings → Secrets and variables → Actions
+2. 點擊 "New repository secret"
+3. Name: `RCLONE_TOKEN`
+4. Value: 貼上完整的 rclone 配置內容（包含 `[gdrive]` 開頭）
+
+## 自動化腳本
+
+我為您建立一個 Python 腳本來自動處理這個轉換： 

--- a/docs/setup-google-drive-integration.md
+++ b/docs/setup-google-drive-integration.md
@@ -1,0 +1,134 @@
+# Google Drive Integration 設定指南
+
+## 步驟 1: 建立 Google Cloud Project
+
+1. 前往 [Google Cloud Console](https://console.cloud.google.com/)
+2. 建立新專案或選擇現有專案
+3. 記下專案 ID
+
+## 步驟 2: 啟用 Google Drive API
+
+1. 在 Google Cloud Console 中，前往「API 和服務」→「程式庫」
+2. 搜尋「Google Drive API」
+3. 點擊並啟用此 API
+
+## 步驟 3: 建立 Service Account
+
+1. 前往「API 和服務」→「憑證」
+2. 點擊「建立憑證」→「服務帳戶」
+3. 填寫服務帳戶詳情：
+   - 名稱：`github-actions-drive-uploader`
+   - 說明：`用於 GitHub Actions 上傳 PR 文檔到 Google Drive`
+4. 跳過角色設定（稍後會直接分享資料夾）
+5. 完成建立
+
+## 步驟 4: 建立和下載金鑰
+
+1. 在憑證頁面找到剛建立的服務帳戶
+2. 點擊服務帳戶名稱進入詳細頁面
+3. 切換到「金鑰」分頁
+4. 點擊「新增金鑰」→「建立新金鑰」
+5. 選擇「JSON」格式
+6. 下載金鑰檔案（請妥善保管！）
+
+## 步驟 5: 建立 Google Drive 資料夾並分享
+
+1. 在 Google Drive 中建立資料夾：`GitHub-PR-Descriptions`
+2. 右鍵點擊資料夾 → 「分享」
+3. 新增您的服務帳戶電子郵件（在 JSON 金鑰檔案中的 `client_email` 欄位）
+4. 給予「編輯者」權限
+
+## 步驟 6: 產生 rclone token
+
+有兩種方法產生 rclone token：
+
+### 方法 A: 使用本機 rclone（推薦）
+
+```bash
+# 安裝 rclone
+curl https://rclone.org/install.sh | bash
+
+# 配置 Google Drive remote
+rclone config
+
+# 選擇：
+# n) New remote
+# name: gdrive
+# Storage: drive (Google Drive)
+# client_id: (直接按 Enter，使用預設)
+# client_secret: (直接按 Enter，使用預設)
+# scope: drive.file
+# service_account_file: /path/to/your/downloaded.json
+# 其他選項保持預設
+
+# 測試連接
+rclone ls gdrive:
+
+# 檢查配置
+rclone config show gdrive
+```
+
+### 方法 B: 手動建立 token（進階）
+
+如果您使用 Service Account，token 格式如下：
+
+```json
+{
+  "access_token": "",
+  "refresh_token": "",
+  "token_type": "Bearer",
+  "expiry": "0001-01-01T00:00:00Z",
+  "service_account": "/path/to/service-account.json"
+}
+```
+
+## 步驟 7: 設定 GitHub Secrets
+
+1. 前往您的 GitHub repository
+2. 點擊「Settings」→「Secrets and variables」→「Actions」
+3. 點擊「New repository secret」
+4. 名稱：`RCLONE_TOKEN`
+5. 值：從 `rclone config show gdrive` 取得的 token 內容
+
+## 步驟 8: 測試設定
+
+建立測試檔案來驗證設定：
+
+```bash
+# 建立測試檔案
+echo "測試上傳" > test.txt
+
+# 上傳測試
+rclone copy test.txt gdrive:GitHub-PR-Descriptions/
+
+# 檢查是否成功
+rclone ls gdrive:GitHub-PR-Descriptions/
+```
+
+## 安全注意事項
+
+1. **金鑰安全**：
+   - 下載的 JSON 金鑰檔案包含敏感資訊，請勿提交到 git
+   - 定期輪換金鑰
+
+2. **權限最小化**：
+   - 服務帳戶只有特定資料夾的存取權限
+   - 使用 `drive.file` scope 而非 `drive` 完整權限
+
+3. **監控**：
+   - 定期檢查 Google Cloud Console 的 API 使用量
+   - 監控 Drive 資料夾的檔案變化
+
+## 故障排除
+
+### 常見錯誤 1: "token expired"
+- 重新產生 rclone token
+- 檢查服務帳戶金鑰是否有效
+
+### 常見錯誤 2: "permission denied"
+- 確認服務帳戶有資料夾的編輯權限
+- 檢查資料夾名稱是否正確
+
+### 常見錯誤 3: "API not enabled"
+- 確認 Google Drive API 已啟用
+- 檢查專案是否正確 

--- a/scripts/debug-rclone-token.py
+++ b/scripts/debug-rclone-token.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""
+RCLONE_TOKEN 除錯工具
+幫助診斷和修復 RCLONE_TOKEN 格式問題
+"""
+
+import json
+import re
+import sys
+
+def debug_rclone_token():
+    print("🔧 RCLONE_TOKEN 除錯工具")
+    print("=" * 50)
+    print("請貼上您目前的 RCLONE_TOKEN 內容，然後按 Enter 兩次:")
+    
+    lines = []
+    while True:
+        try:
+            line = input()
+            if line == "" and lines:
+                break
+            lines.append(line)
+        except EOFError:
+            break
+    
+    token_content = "\n".join(lines)
+    
+    if not token_content.strip():
+        print("❌ 沒有提供任何內容")
+        return
+    
+    print("\n🔍 分析 RCLONE_TOKEN...")
+    print("=" * 50)
+    
+    # 檢查基本結構
+    if not re.search(r'\[gdrive\]', token_content):
+        print("❌ 缺少 [gdrive] section")
+        return
+    
+    # 提取 service_account_credentials
+    match = re.search(r'service_account_credentials\s*=\s*(.+)', token_content)
+    if not match:
+        print("❌ 找不到 service_account_credentials")
+        return
+    
+    json_content = match.group(1).strip()
+    print(f"📋 找到 JSON 內容 ({len(json_content)} 字元)")
+    
+    # 顯示 JSON 的前後字元來診斷問題
+    print(f"🔍 JSON 開始字元: {repr(json_content[:20])}")
+    print(f"🔍 JSON 結束字元: {repr(json_content[-20:])}")
+    
+    # 嘗試解析 JSON
+    try:
+        service_account = json.loads(json_content)
+        print("✅ JSON 解析成功!")
+        
+        # 檢查必要欄位
+        required_fields = ['type', 'project_id', 'private_key', 'client_email']
+        for field in required_fields:
+            if field in service_account:
+                print(f"✅ {field}: {service_account[field][:50] if len(str(service_account[field])) > 50 else service_account[field]}")
+            else:
+                print(f"❌ 缺少 {field}")
+        
+    except json.JSONDecodeError as e:
+        print(f"❌ JSON 解析失敗: {e}")
+        print(f"錯誤位置: 第 {e.lineno} 行, 第 {e.colno} 欄")
+        
+        # 嘗試找出問題
+        print("\n🔧 診斷和修復建議:")
+        
+        # 檢查常見問題
+        if json_content.startswith('t'):
+            print("- 看起來 JSON 前面有多餘的文字")
+        
+        if not json_content.startswith('{'):
+            print("- JSON 應該以 '{' 開始")
+            print(f"- 但您的開始是: {repr(json_content[:10])}")
+        
+        if not json_content.endswith('}'):
+            print("- JSON 應該以 '}' 結束")
+            print(f"- 但您的結束是: {repr(json_content[-10:])}")
+        
+        # 嘗試找到 JSON 的真正開始
+        start_idx = json_content.find('{')
+        end_idx = json_content.rfind('}')
+        
+        if start_idx != -1 and end_idx != -1:
+            clean_json = json_content[start_idx:end_idx+1]
+            print(f"\n💡 嘗試清理後的 JSON ({len(clean_json)} 字元):")
+            print(f"開始: {repr(clean_json[:20])}")
+            print(f"結束: {repr(clean_json[-20:])}")
+            
+            try:
+                cleaned_service_account = json.loads(clean_json)
+                print("✅ 清理後的 JSON 可以解析!")
+                
+                # 重新產生 rclone 配置
+                print("\n🔧 修復後的 RCLONE_TOKEN:")
+                print("-" * 50)
+                fixed_config = f"""[gdrive]
+type = drive
+scope = drive.file
+service_account_credentials = {json.dumps(cleaned_service_account, separators=(',', ':'))}"""
+                print(fixed_config)
+                print("-" * 50)
+                print("請使用上面的內容重新設定 RCLONE_TOKEN")
+                
+            except json.JSONDecodeError as e2:
+                print(f"❌ 清理後仍無法解析: {e2}")
+    
+    print("\n💡 一般修復步驟:")
+    print("1. 重新運行 scripts/generate-rclone-token.py")
+    print("2. 確保複製完整的輸出內容")
+    print("3. 檢查沒有多餘的空行或文字")
+    print("4. 重新設定 GitHub Secret")
+
+if __name__ == "__main__":
+    debug_rclone_token() 

--- a/scripts/generate-rclone-token.py
+++ b/scripts/generate-rclone-token.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""
+Service Account JSON 轉 rclone 配置工具
+自動將 Google Service Account JSON 轉換為 GitHub Actions 可用的 RCLONE_TOKEN
+"""
+
+import json
+import sys
+import os
+from pathlib import Path
+
+def main():
+    print("🔑 Service Account JSON 轉 rclone 配置工具")
+    print("=" * 50)
+    
+    # 取得 JSON 檔案路徑
+    if len(sys.argv) > 1:
+        json_file = sys.argv[1]
+    else:
+        json_file = input("請輸入 Service Account JSON 檔案路徑: ").strip()
+    
+    # 檢查檔案是否存在
+    if not os.path.exists(json_file):
+        print(f"❌ 找不到檔案: {json_file}")
+        sys.exit(1)
+    
+    try:
+        # 讀取並驗證 JSON
+        with open(json_file, 'r', encoding='utf-8') as f:
+            service_account_data = json.load(f)
+        
+        # 檢查必要欄位
+        required_fields = ['type', 'project_id', 'private_key', 'client_email']
+        missing_fields = [field for field in required_fields if field not in service_account_data]
+        
+        if missing_fields:
+            print(f"❌ JSON 檔案缺少必要欄位: {', '.join(missing_fields)}")
+            sys.exit(1)
+        
+        if service_account_data.get('type') != 'service_account':
+            print("❌ 這不是一個有效的 Service Account JSON 檔案")
+            sys.exit(1)
+        
+        print(f"✅ JSON 檔案驗證成功")
+        print(f"📧 Service Account Email: {service_account_data['client_email']}")
+        print(f"🏗️  Project ID: {service_account_data['project_id']}")
+        
+        # 壓縮 JSON（移除空格和換行）
+        compressed_json = json.dumps(service_account_data, separators=(',', ':'))
+        
+        # 產生 rclone 配置
+        rclone_config = f"""[gdrive]
+type = drive
+scope = drive.file
+service_account_credentials = {compressed_json}"""
+        
+        print("\n" + "=" * 50)
+        print("🎯 GitHub Secret 設定")
+        print("=" * 50)
+        print("1. 前往 GitHub repository → Settings → Secrets and variables → Actions")
+        print("2. 點擊 'New repository secret'")
+        print("3. Name: RCLONE_TOKEN")
+        print("4. Value: 複製以下完整內容")
+        print("\n" + "-" * 50)
+        print("RCLONE_TOKEN 內容:")
+        print("-" * 50)
+        print(rclone_config)
+        print("-" * 50)
+        
+        # 儲存到檔案（可選）
+        output_file = "rclone-config.txt"
+        with open(output_file, 'w', encoding='utf-8') as f:
+            f.write(rclone_config)
+        
+        print(f"\n💾 配置已儲存到: {output_file}")
+        print("\n⚠️  安全提醒:")
+        print("- 請立即刪除此檔案，避免洩露敏感資訊")
+        print("- 確保 Service Account JSON 檔案安全儲存")
+        print("- 定期輪換 Service Account 金鑰")
+        
+        print("\n✅ 設定完成！")
+        print("\n🧪 測試步驟:")
+        print("1. 在 Google Drive 建立 'GitHub-PR-Descriptions' 資料夾")
+        print(f"2. 將資料夾分享給: {service_account_data['client_email']}")
+        print("3. 給予編輯者權限")
+        print("4. 建立 PR 測試自動上傳功能")
+        
+    except json.JSONDecodeError as e:
+        print(f"❌ JSON 格式錯誤: {e}")
+        sys.exit(1)
+    except Exception as e:
+        print(f"❌ 處理失敗: {e}")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main() 

--- a/scripts/generate-rclone-token.py
+++ b/scripts/generate-rclone-token.py
@@ -48,11 +48,24 @@ def main():
         # 壓縮 JSON（移除空格和換行）
         compressed_json = json.dumps(service_account_data, separators=(',', ':'))
         
+        # 驗證壓縮後的 JSON 能否重新解析
+        try:
+            json.loads(compressed_json)
+            print("✅ JSON 壓縮和驗證成功")
+        except json.JSONDecodeError as e:
+            print(f"❌ JSON 壓縮後驗證失敗: {e}")
+            sys.exit(1)
+        
         # 產生 rclone 配置
         rclone_config = f"""[gdrive]
 type = drive
 scope = drive.file
 service_account_credentials = {compressed_json}"""
+        
+        # 驗證生成的 rclone 配置
+        if not rclone_config.startswith('[gdrive]'):
+            print("❌ rclone 配置格式錯誤")
+            sys.exit(1)
         
         print("\n" + "=" * 50)
         print("🎯 GitHub Secret 設定")

--- a/scripts/setup-gdrive-token.sh
+++ b/scripts/setup-gdrive-token.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+# Google Drive Token 設定腳本
+# 用於產生 GitHub Actions 需要的 RCLONE_TOKEN
+
+set -e
+
+echo "🚀 Google Drive Integration 設定腳本"
+echo "======================================"
+
+# 檢查是否安裝 rclone
+if ! command -v rclone &> /dev/null; then
+    echo "📦 安裝 rclone..."
+    curl https://rclone.org/install.sh | bash
+fi
+
+echo "📝 請確保您已完成以下步驟："
+echo "1. ✅ 在 Google Cloud Console 建立專案並啟用 Drive API"
+echo "2. ✅ 建立 Service Account 並下載 JSON 金鑰檔案"
+echo "3. ✅ 在 Google Drive 建立 'GitHub-PR-Descriptions' 資料夾"
+echo "4. ✅ 將資料夾分享給服務帳戶電子郵件"
+echo ""
+
+read -p "請輸入 Service Account JSON 檔案的完整路徑: " SERVICE_ACCOUNT_FILE
+
+if [ ! -f "$SERVICE_ACCOUNT_FILE" ]; then
+    echo "❌ 找不到檔案: $SERVICE_ACCOUNT_FILE"
+    exit 1
+fi
+
+echo "📧 從 JSON 檔案讀取服務帳戶資訊..."
+SERVICE_EMAIL=$(cat "$SERVICE_ACCOUNT_FILE" | grep -o '"client_email": *"[^"]*"' | cut -d'"' -f4)
+echo "   服務帳戶電子郵件: $SERVICE_EMAIL"
+
+echo ""
+echo "🔧 配置 rclone..."
+
+# 建立 rclone 配置
+mkdir -p ~/.config/rclone
+
+cat > ~/.config/rclone/rclone.conf << EOF
+[gdrive]
+type = drive
+scope = drive.file
+service_account_file = $SERVICE_ACCOUNT_FILE
+EOF
+
+echo "✅ rclone 配置已建立"
+
+echo ""
+echo "🧪 測試連接..."
+
+if rclone ls gdrive: > /dev/null 2>&1; then
+    echo "✅ Google Drive 連接成功！"
+else
+    echo "❌ Google Drive 連接失敗"
+    echo "請檢查："
+    echo "- Service Account JSON 檔案是否正確"
+    echo "- Google Drive API 是否已啟用"
+    echo "- 是否已分享資料夾給服務帳戶"
+    exit 1
+fi
+
+echo ""
+echo "📂 檢查目標資料夾..."
+
+if rclone ls gdrive:GitHub-PR-Descriptions > /dev/null 2>&1; then
+    echo "✅ 找到 GitHub-PR-Descriptions 資料夾"
+else
+    echo "❌ 找不到 GitHub-PR-Descriptions 資料夾"
+    echo "請確保："
+    echo "1. 在 Google Drive 建立名為 'GitHub-PR-Descriptions' 的資料夾"
+    echo "2. 將資料夾分享給服務帳戶: $SERVICE_EMAIL"
+    echo "3. 給予編輯者權限"
+    exit 1
+fi
+
+echo ""
+echo "🔑 產生 GitHub Secret..."
+
+# 顯示需要設定的 token
+echo "請將以下內容設定為 GitHub Secret 'RCLONE_TOKEN':"
+echo ""
+echo "=================================================="
+rclone config show gdrive | grep -A 10 -B 2 '\[gdrive\]'
+echo "=================================================="
+
+echo ""
+echo "📋 GitHub 設定步驟："
+echo "1. 前往 GitHub repository → Settings → Secrets and variables → Actions"
+echo "2. 點擊 'New repository secret'"
+echo "3. Name: RCLONE_TOKEN"
+echo "4. Value: 複製上面 [gdrive] 區塊的完整內容"
+echo ""
+
+echo "🎉 設定完成！"
+echo ""
+echo "💡 提示："
+echo "- 如需重新設定，執行: rclone config"
+echo "- 測試上傳: rclone copy test.txt gdrive:GitHub-PR-Descriptions/"
+echo "- 查看檔案: rclone ls gdrive:GitHub-PR-Descriptions/" 

--- a/scripts/validate-rclone-token.py
+++ b/scripts/validate-rclone-token.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""
+RCLONE_TOKEN 驗證工具
+檢查 GitHub Secret 中的 RCLONE_TOKEN 格式是否正確
+"""
+
+import sys
+import re
+
+def validate_rclone_token(token_content):
+    """驗證 rclone token 的格式"""
+    errors = []
+    warnings = []
+    
+    # 檢查是否包含 [gdrive] section
+    if not re.search(r'\[gdrive\]', token_content):
+        errors.append("❌ 缺少 [gdrive] section header")
+    
+    # 檢查必要的欄位
+    required_fields = [
+        'type = drive',
+        'scope = drive.file',
+        'service_account_credentials'
+    ]
+    
+    for field in required_fields:
+        if field not in token_content:
+            errors.append(f"❌ 缺少必要欄位: {field}")
+    
+    # 檢查 service_account_credentials 格式
+    if 'service_account_credentials' in token_content:
+        # 提取 JSON 部分
+        json_match = re.search(r'service_account_credentials = (.+)', token_content)
+        if json_match:
+            json_content = json_match.group(1)
+            
+            # 檢查是否包含必要的 Service Account 欄位
+            sa_fields = ['type', 'project_id', 'private_key', 'client_email']
+            for field in sa_fields:
+                if f'"{field}"' not in json_content:
+                    errors.append(f"❌ Service Account JSON 缺少欄位: {field}")
+            
+            # 檢查是否為 service_account 類型
+            if '"type":"service_account"' not in json_content:
+                errors.append("❌ Service Account type 不正確")
+        else:
+            errors.append("❌ service_account_credentials 格式不正確")
+    
+    # 檢查是否有多餘的空行或格式問題
+    lines = token_content.strip().split('\n')
+    if len(lines) < 3:
+        warnings.append("⚠️ 配置內容似乎太短")
+    
+    return errors, warnings
+
+def main():
+    print("🔍 RCLONE_TOKEN 驗證工具")
+    print("=" * 50)
+    
+    if len(sys.argv) > 1:
+        # 從檔案讀取
+        try:
+            with open(sys.argv[1], 'r', encoding='utf-8') as f:
+                token_content = f.read()
+            print(f"📄 從檔案讀取: {sys.argv[1]}")
+        except FileNotFoundError:
+            print(f"❌ 找不到檔案: {sys.argv[1]}")
+            sys.exit(1)
+    else:
+        # 從標準輸入讀取
+        print("📝 請貼上您的 RCLONE_TOKEN 內容，然後按 Ctrl+D (Linux/Mac) 或 Ctrl+Z (Windows):")
+        token_content = sys.stdin.read()
+    
+    if not token_content.strip():
+        print("❌ 沒有提供任何內容")
+        sys.exit(1)
+    
+    print("\n🔍 分析中...")
+    errors, warnings = validate_rclone_token(token_content)
+    
+    print("\n" + "=" * 50)
+    print("📊 驗證結果")
+    print("=" * 50)
+    
+    if not errors and not warnings:
+        print("✅ RCLONE_TOKEN 格式看起來正確！")
+        print("\n📋 檢測到的配置:")
+        
+        # 顯示基本資訊（隱藏敏感資料）
+        if '[gdrive]' in token_content:
+            print("- ✅ [gdrive] section")
+        if 'type = drive' in token_content:
+            print("- ✅ Google Drive 類型")
+        if 'scope = drive.file' in token_content:
+            print("- ✅ 檔案存取權限")
+        if 'service_account_credentials' in token_content:
+            print("- ✅ Service Account 認證")
+            
+            # 嘗試提取 project_id 和 client_email
+            import json
+            try:
+                json_match = re.search(r'service_account_credentials = (.+)', token_content)
+                if json_match:
+                    sa_json = json.loads(json_match.group(1))
+                    if 'project_id' in sa_json:
+                        print(f"- 📁 Project ID: {sa_json['project_id']}")
+                    if 'client_email' in sa_json:
+                        print(f"- 📧 Service Account: {sa_json['client_email']}")
+            except:
+                pass
+    
+    if warnings:
+        print("\n⚠️ 警告:")
+        for warning in warnings:
+            print(f"  {warning}")
+    
+    if errors:
+        print("\n❌ 錯誤:")
+        for error in errors:
+            print(f"  {error}")
+        
+        print("\n💡 修復建議:")
+        print("1. 確保使用 scripts/generate-rclone-token.py 產生 token")
+        print("2. 檢查 Service Account JSON 檔案是否完整")
+        print("3. 確保格式為:")
+        print("""
+   [gdrive]
+   type = drive
+   scope = drive.file
+   service_account_credentials = {"type":"service_account",...}
+   """)
+        
+        sys.exit(1)
+    
+    print("\n🚀 下一步:")
+    print("1. 將此內容設定為 GitHub Secret 'RCLONE_TOKEN'")
+    print("2. 確保 Google Drive 資料夾已分享給 Service Account")
+    print("3. 測試 GitHub Actions workflow")
+
+if __name__ == "__main__":
+    main() 


### PR DESCRIPTION
## 背景描述 (Why)

為了更好地管理和歸檔 Pull Request 的內容，需要實作自動將 PR 描述保存到 Google Drive 的功能。這樣可以方便團隊進行 PR 審查記錄的管理和後續查詢。

## 實作方法 (How)

1. 建立新的 GitHub Actions workflow 來監聽 PR 事件
2. 使用 GitHub Script 讀取 PR 資訊並生成 Markdown 檔案
3. 整合 rclone 工具來上傳檔案到 Google Drive
4. 使用 Service Account 進行安全的 API 存取
5. 提供完整的設定工具和文檔

## 實際變更 (做了什麼)

- [x] 功能1：PR 描述自動保存
  - 新增  workflow
  - 監聽 PR 建立、編輯、重新開啟和同步事件
  - 自動生成以分支名稱命名的 Markdown 檔案
  - 上傳到 Google Drive 指定資料夾
- [x] 功能2：完整設定工具和文檔
  - 建立 Service Account 設定指南
  - 提供 Python 自動轉換工具
  - 建立故障排除文檔
  - 加入安全性最佳實踐

### 技術細節

- 使用  讀取 PR 資訊
- 整合 rclone 進行 Google Drive API 操作
- 支援 Service Account credentials 認證
- 自動處理分支名稱中的特殊字元
- 加入錯誤處理和清理機制

### 新增檔案

-  - 主要 workflow
-  - 完整設定指南
-  - Service Account 快速設定
-  - 自動轉換工具
-  - 手動設定腳本
-  - 快速開始指南

### 測試驗證

- [x] GitHub Actions workflow 語法驗證
- [x] rclone 配置格式驗證
- [x] Service Account JSON 處理邏輯測試
- [x] 檔案命名和路徑處理測試

## 補充說明

- 需要設定  GitHub Secret
- 使用 Service Account 確保安全性
- 支援自動建立目標資料夾
- 包含完整的故障排除指南
- 遵循最小權限原則（drive.file scope）

## 相關連結

- Google Drive API 文檔
- rclone 官方文檔
- GitHub Actions 最佳實踐